### PR TITLE
Add training columns to monster data

### DIFF
--- a/load_monster_data.py
+++ b/load_monster_data.py
@@ -29,6 +29,10 @@ def load_monster_data(part1_path="en_sqlout_1.csv", part2_path="en_sqlout_2.csv"
         inplace=True,
     )
 
+    # Add additional training information used in speedrun notes
+    df["WeeksAvail"] = df["Lifespan"].clip(upper=104)
+    df["HeavyCycles"] = (df["WeeksAvail"] // 4).astype(int)
+
     return df
 
 


### PR DESCRIPTION
## Summary
- calculate available training weeks capped at 104
- derive count of heavy training cycles from available weeks

## Testing
- `python load_monster_data.py`